### PR TITLE
Fix FileNotFound bug

### DIFF
--- a/bin/pymail.py
+++ b/bin/pymail.py
@@ -24,7 +24,27 @@ def get_receiver_email_list():
 			break
 
 	return receivers_list		
+def get_attachment_part():
+	while True:
+		filename = input('Enter filename for attachments: ')
 
+		try:
+			with open(filename, 'rb') as attachment:
+				part = MIMEBase("application", "octet-stream")
+				part.set_payload(attachment.read())
+				encoders.encode_base64(part)
+				part.add_header(
+					"Content-Disposition",
+					f"attachment; filename= {filename}",
+				)
+				return part
+
+		except FileNotFoundError:
+			print(f"Error: '{filename}' was not found.")
+			retry = input('Try a different filename? (Y/N): ')
+			if retry not in ['y', 'Y']:
+				print("Continuing without attachment.")
+				return None
 def main():
 
 	sender_email, password = get_sender_details()
@@ -45,21 +65,13 @@ def main():
 		# Add body to email
 		message.attach(MIMEText(body, "plain"))
 
+		part = None
 		if input('Any attachments?(Y/N): ') in ['y', 'Y']:
-			
-			filename = input('Enter filename for attachments: ')
-			with open(filename, 'rb') as attachment:
-				part = MIMEBase("application","octet-stream")
-				part.set_payload(attachment.read())
-
-			# Add header as key/value pair to attachment part
-			part.add_header(
-    			"Content-Disposition",
-    			f"attachment; filename= {filename}",
-			)
+			part = get_attachment_part()
 
 		# Add attachment to message and convert message to string
-		message.attach(part)
+		if part is not None : 
+			message.attach(part)
 		text = message.as_string()
 
 		# Log in to server using secure context and send email


### PR DESCRIPTION
## Fix: Nonexistent attachment file crashes with unhandled `FileNotFoundError`

Closes #9

### Problem
Entering a filename that doesn't exist when prompted for an attachment crashed the entire script with a raw, unhandled `FileNotFoundError` traceback instead of a friendly message.

### Root cause
`bin/pymail.py` `main()` called `open(filename, 'rb')` directly with no surrounding error handling. Additionally, the `part` variable was only defined inside the attachment `if` block, so `message.attach(part)` could throw `NameError` on runs with no attachment.

### Fix
- Extracted the attachment-reading logic into a new `get_attachment_part()` function.
- Wrapped the `open()` call in a `try` / `except FileNotFoundError` block.
- On a missing file, the user now sees a clear error message and is prompted to either retry with a different filename or continue sending without an attachment.
- `part` now defaults to `None` and is only attached to the message if a valid file was actually read, fixing the possible `NameError`/stale-attachment issue.
- Added the missing `encoders.encode_base64(part)` call (previously imported but unused) so binary attachments are properly encoded before sending.

### Changes
- `bin/pymail.py`
  - Added `get_attachment_part()`
  - Updated the attachment block in `main()` to use it and guard the `message.attach(part)` call with `if part is not None`

### Testing
Manually tested:
1. Entered a nonexistent filename → friendly error shown, prompted to retry.
2. Retried with valid filename → attachment sent successfully.
3. Retried with nonexistent filename and declined retry → email sent successfully with no attachment (no crash).

### Acceptance criteria met
- [x] Entering a nonexistent filename produces a clear, friendly error message instead of an unhandled traceback.